### PR TITLE
Fixed bug identity matrix in RGE

### DIFF
--- a/src/smefit/rge.py
+++ b/src/smefit/rge.py
@@ -450,16 +450,8 @@ def load_rge_matrix(
         rgemat = []
         rge_cache = {}
         for scale in scales:
-            if scale == init_scale:
-                # produce an identity matrix with row and columns coeff_list
-                rgemat_scale = pd.DataFrame(
-                    np.eye(len(coeff_list), len(coeff_list)),
-                    columns=sorted(coeff_list),
-                    index=sorted(coeff_list),
-                )
-
             # Check if the RGE matrix has already been computed
-            elif scale in rge_cache:
+            if scale in rge_cache:
                 rgemat_scale = rge_cache[scale]
             else:
                 rgemat_scale = rge_runner.RGEmatrix(scale)


### PR DESCRIPTION
This RGE fixes a bug that is present in a very niche scenario, i.e.:
- there is a UV coupling
- the initial scale and the observable scale are the same

If those conditions are met, an identity matrix was produced containing the UV coupling in the observable scale operators (it was a square matrix). However, this is wrong as the UV coupling does not exist here and there should always be a column of zeros for the UV coupling (we only evolve the WC).
The fix is to simply remove this special case, since wilson already returns the correct thing if you ask to evolve between two scales that are the same.

E.g. if I have a UV coupling "m" which generates Opd and Op, the correct "identity matrix" when init and obs scale are the same should be
```
      Op  Opd    m
Op   1.0  0.0  0.0
Opd  0.0  1.0  0.0
``` 

while in main it would currently produce
```
      Op  Opd    m
Op   1.0  0.0  0.0
Opd  0.0  1.0  0.0
m    0.0  0.0  1.0
```