### PR TITLE
Support for arrays of luminosity.

### DIFF
--- a/src/smefit/loader.py
+++ b/src/smefit/loader.py
@@ -675,7 +675,7 @@ def load_datasets(
 
         exp_name.append(dataset_name)
         n_data_exp.append(dataset.n_data)
-        lumi_exp.append(dataset.lumi)
+#        lumi_exp.append(dataset.lumi)
         exp_data.extend(dataset.central_values)
         sm_theory.extend(dataset.sm_prediction)
         lin_corr_list.append([dataset.n_data, dataset.lin_corrections])


### PR DESCRIPTION
The implementation of ILC/CLIC datasets requires the support of arrays for the luminosity because those datasets are grouped by polarization and hence have data points with different energies and luminosities.

The luminosity is not required for the fit, but it was still being read. As a quick fix, the luminosity is not loaded. In the future, we want to support arrays for the luminosity.