### PR TITLE
Keeping ordering coefficients from report runcard

### DIFF
--- a/src/smefit/analyze/coefficients_utils.py
+++ b/src/smefit/analyze/coefficients_utils.py
@@ -180,6 +180,7 @@ class CoefficientsPlotter:
         colors = plt.get_cmap("tab20")
 
         def plot_error_bars(ax, vals, cnt, i, label=None):
+
             ax.errorbar(
                 x=vals.mid,
                 y=Y[cnt] + y_shift[i],
@@ -202,8 +203,13 @@ class CoefficientsPlotter:
             # loop over fits
             for i, (fit_name, bound_df) in enumerate(bounds.items()):
                 label = fit_name
+                bound_df_top_to_bottom = bound_df[g].iloc[
+                    :, ::-1
+                ]  # reverse order to plot from top to bottom in ax
                 # loop on coeffs
-                for cnt, (coeff_name, coeff) in enumerate(bound_df[g].items()):
+                for cnt, (coeff_name, coeff) in enumerate(
+                    bound_df_top_to_bottom.items()
+                ):
                     # maybe there are no double solutions
                     key_not_found = f"{coeff_name} posterior is not found in {fit_name}"
                     try:
@@ -222,9 +228,10 @@ class CoefficientsPlotter:
                     except KeyError:
                         pass
 
-            # y thicks
+            # y ticks
             ax.set_ylim(-2, Y[-1] + 2)
-            ax.set_yticks(Y, self.coeff_info[g], fontsize=13)
+            # also position y tick labels from top to bottom
+            ax.set_yticks(Y[::-1], self.coeff_info[g], fontsize=13)
             # x grid
             ax.vlines(0, -2, Y[-1] + 2, ls="dashed", color="black", alpha=0.7)
             if x_log:
@@ -247,7 +254,16 @@ class CoefficientsPlotter:
 
         self._plot_logo(axs[-1])
         axs[-1].set_xlabel(r"$c_i/\Lambda^2\ ({\rm TeV}^{-2})$", fontsize=20)
-        axs[0].legend(loc=0, frameon=False, prop={"size": 13})
+        handles, labels = axs[-1].get_legend_handles_labels()
+        axs[0].legend(
+            handles,
+            labels,
+            loc="lower center",
+            bbox_to_anchor=(0, 1.1, 1.0, 0.05),
+            frameon=False,
+            prop={"size": 13},
+            ncol=2,
+        )
         plt.tight_layout()
         plt.savefig(f"{self.report_folder}/coefficient_central.pdf", dpi=500)
         plt.savefig(f"{self.report_folder}/coefficient_central.png")
@@ -317,7 +333,6 @@ class CoefficientsPlotter:
         axs[-1].set_xlabel(
             r"$95\%\ {\rm Confidence\ Level\ Bounds}\ (1/{\rm TeV}^2)$", fontsize=20
         )
-        # axs[0].legend(loc=legend_loc, frameon=False, prop={"size": 13})
         axs[0].legend(
             loc="lower center",
             bbox_to_anchor=(0, 1.1, 1.0, 0.05),

--- a/src/smefit/analyze/coefficients_utils.py
+++ b/src/smefit/analyze/coefficients_utils.py
@@ -372,8 +372,11 @@ class CoefficientsPlotter:
         df = pd.DataFrame(pull)
         groups, axs = self._get_suplblots(figsize)
 
-        for ax, (g, bars) in zip(axs, df.groupby(level=0)):
-            bars.droplevel(0).plot(
+        for ax, (g, bars) in zip(axs, df.groupby(level=0, sort=False)):
+            bars_top_to_bottom = bars.iloc[
+                ::-1
+            ]  # reverse order to plot from top to bottom in ax
+            bars_top_to_bottom.droplevel(0).plot(
                 kind="barh",
                 width=0.6,
                 ax=ax,
@@ -386,7 +389,14 @@ class CoefficientsPlotter:
 
         self._plot_logo(axs[-1])
         axs[-1].set_xlabel(r"${\rm Fit\:Residual\:}(\sigma)$", fontsize=20)
-        axs[0].legend(loc=legend_loc, frameon=False, prop={"size": 13})
+        # axs[0].legend(loc=legend_loc, frameon=False, prop={"size": 13})
+        axs[0].legend(
+            loc="lower center",
+            bbox_to_anchor=(0, 1.1, 1.0, 0.05),
+            frameon=False,
+            prop={"size": 13},
+            ncol=2,
+        )
         plt.tight_layout()
         plt.savefig(f"{self.report_folder}/coefficient_pull.pdf", dpi=500)
         plt.savefig(f"{self.report_folder}/coefficient_pull.png")

--- a/src/smefit/analyze/coefficients_utils.py
+++ b/src/smefit/analyze/coefficients_utils.py
@@ -148,7 +148,7 @@ class CoefficientsPlotter:
             )
 
     def _get_suplblots(self, figsize):
-        groups = self.coeff_info.groupby(level=0).count()
+        groups = self.coeff_info.groupby(level=0, sort=False).count()
         _, axs = plt.subplots(
             groups.size,
             1,
@@ -286,8 +286,11 @@ class CoefficientsPlotter:
         df = pd.DataFrame(error)
         groups, axs = self._get_suplblots(figsize)
 
-        for ax, (g, bars) in zip(axs, df.groupby(level=0)):
-            bars.droplevel(0).plot(
+        for ax, (g, bars) in zip(axs, df.groupby(level=0, sort=False)):
+            bars_top_to_bottom = bars.iloc[
+                ::-1
+            ]  # reverse order to plot from top to bottom in ax
+            bars_top_to_bottom.droplevel(0).plot(
                 kind="barh",
                 width=0.6,
                 ax=ax,
@@ -314,7 +317,14 @@ class CoefficientsPlotter:
         axs[-1].set_xlabel(
             r"$95\%\ {\rm Confidence\ Level\ Bounds}\ (1/{\rm TeV}^2)$", fontsize=20
         )
-        axs[0].legend(loc=legend_loc, frameon=False, prop={"size": 13})
+        # axs[0].legend(loc=legend_loc, frameon=False, prop={"size": 13})
+        axs[0].legend(
+            loc="lower center",
+            bbox_to_anchor=(0, 1.1, 1.0, 0.05),
+            frameon=False,
+            prop={"size": 13},
+            ncol=2,
+        )
         plt.tight_layout()
         plt.savefig(f"{self.report_folder}/coefficient_bar.pdf", dpi=500)
         plt.savefig(f"{self.report_folder}/coefficient_bar.png")


### PR DESCRIPTION
This PR gives the user more flexibility on the ordering of the coefficients in the barplots (`coefficient_bar, coefficient_central, coefficient_pull`). Before, the coefficients and groups (`4H, 2FB`, etc) were ordered alphabetically, which is often not what we want. Instead this PR keeps the ordering as specified in the report runcard, e.g.

```
coeff_info:
  4H: [
    [OQQ1, "$c_{QQ}^{1}$"],
    [OQQ8, "$c_{QQ}^{8}$"],
    [OQt1, "$c_{Qt}^{1}$"],
    [.... ],
  2L2H: [ 
     [....],
    ]
```
plots from top to bottom, the 4H starting with OQQ1, the 2L2H, etc..

In terms of plots this means,

this PR:
![coefficient_bar](https://github.com/user-attachments/assets/5f53fd10-1063-4c3e-a0ea-d3c356102726)

main:
![coefficient_bar](https://github.com/user-attachments/assets/07c3606c-fc89-45cc-8c79-a92fd1badc77)

I have also repositioned the legend. 
