### PR TITLE
Fix writing of results in single parameter fits

### DIFF
--- a/src/smefit/optimize/__init__.py
+++ b/src/smefit/optimize/__init__.py
@@ -256,12 +256,13 @@ class Optimizer:
                 with open(fit_result_file, encoding="utf-8") as f:
                     tmp = json.load(f)
                     # Get the operator name
-                    coeff = list(values["samples"].keys())[0]
+                    coeff = values["free_parameters"][0]
                     # update the values
                     tmp["logz"][coeff] = values["logz"]
                     tmp["max_loglikelihood"][coeff] = values["max_loglikelihood"]
                     tmp["best_fit_point"][coeff] = values["best_fit_point"][coeff]
                     tmp["samples"][coeff] = values["samples"][coeff]
+                    tmp["free_parameters"].append(values["free_parameters"][0])
                     # update the file with the new values
                     with open(fit_result_file, "w", encoding="utf-8") as f:
                         json.dump(tmp, f, indent=4, cls=NumpyEncoder)
@@ -270,9 +271,11 @@ class Optimizer:
                 values["single_parameter_fits"] = True
                 with open(fit_result_file, "w", encoding="utf-8") as f:
                     # Get the operator name
-                    coeff = list(values["best_fit_point"].keys())[0]
+                    coeff = values["free_parameters"][0]
                     values["logz"] = {coeff: values["logz"]}
                     values["max_loglikelihood"] = {coeff: values["max_loglikelihood"]}
+                    values["best_fit_point"] = {coeff: values["best_fit_point"][coeff]}
+                    values["samples"] = {coeff: values["samples"][coeff]}
                     json.dump(values, f, indent=4, cls=NumpyEncoder)
 
         else:

--- a/src/smefit/optimize/analytic.py
+++ b/src/smefit/optimize/analytic.py
@@ -141,6 +141,8 @@ class ALOptimizer(Optimizer):
         """Run sapmling accordying to the analytic solution."""
 
         fit_result = {}
+        # add names of the free parameters
+        fit_result["free_parameters"] = self.coefficients.free_parameters.index.tolist()
 
         # update linear corrections in casde
         new_LinearCorrections = impose_constrain(

--- a/src/smefit/optimize/ultranest.py
+++ b/src/smefit/optimize/ultranest.py
@@ -474,6 +474,7 @@ class USOptimizer(Optimizer):
             "logz": logz,
             "max_loglikelihood": max_loglikelihood,
             "best_fit_point": best_fit_point,
+            "free_parameters": self.coefficients.free_parameters.index.tolist(),
         }
 
         self.dump_fit_result(fit_results_file, fit_result)

--- a/src/smefit/runner.py
+++ b/src/smefit/runner.py
@@ -209,7 +209,7 @@ class Runner:
 
             # skip contrained coeffs
             if "constrain" in config["coefficients"][coeff]:
-                _logger.info("Skipping contrained coefficient %s", coeff)
+                _logger.info("Skipping constrained coefficient %s", coeff)
                 continue
 
             # if there are constrained coefficients, only

--- a/src/smefit/runner.py
+++ b/src/smefit/runner.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-import importlib
 import itertools
 import pathlib
+import shutil
 import subprocess
 import sys
 from shutil import copyfile
@@ -65,9 +65,9 @@ class Runner:
         else:
             res_folder_fit = result_folder / result_ID
 
-        subprocess.call(f"mkdir -p {result_folder}", shell=True)
         if res_folder_fit.exists():
             _logger.warning(f"{res_folder_fit} already found, overwriting old results")
+            shutil.rmtree(res_folder_fit)
         subprocess.call(f"mkdir -p {res_folder_fit}", shell=True)
 
         # Copy yaml runcard to results folder or dump it


### PR DESCRIPTION
This PR addresses #117 .
It does so by adding a new key in the fit_results, namely the list of free parameters of the fit. This is then used in the single parameter fit to figure out which of the parameters is the one to write in the result.

Also, I think writing which of the coefficients is free in the fit_result.json is a good feature generically for all the fits.