### PR TITLE
2d plot with tight layout

### DIFF
--- a/src/smefit/analyze/coefficients_utils.py
+++ b/src/smefit/analyze/coefficients_utils.py
@@ -916,8 +916,8 @@ class CoefficientsPlotter:
             verticalalignment="top",
         )
 
-        fig.savefig(f"{self.report_folder}/contours_2d.pdf")
-        fig.savefig(f"{self.report_folder}/contours_2d.png")
+        fig.savefig(f"{self.report_folder}/contours_2d.pdf", bbox_inches="tight")
+        fig.savefig(f"{self.report_folder}/contours_2d.png", bbox_inches="tight")
 
     def write_cl_table(self, bounds, round_val=3):
         """Coefficients latex table"""


### PR DESCRIPTION
This PR simply makes the layout of the 2D plots tight so that the space on the page is fully taken advantage of and nothing is cutout.