### PR TITLE
Removed intervals from text in 2D plots

### DIFF
--- a/src/smefit/analyze/coefficients_utils.py
+++ b/src/smefit/analyze/coefficients_utils.py
@@ -910,7 +910,7 @@ class CoefficientsPlotter:
         ax.text(
             0.05,
             0.95,
-            rf"$\mathrm{{Marginalised}}\:{cl}\:\%\:\mathrm{{C.I.\:intervals}}$",
+            rf"$\mathrm{{Marginalised}}\:{cl}\:\%\:\mathrm{{C.I.}}$",
             fontsize=24,
             transform=ax.transAxes,
             verticalalignment="top",


### PR DESCRIPTION
This PR removes the word "intervals" from the 2D plots.