### PR TITLE
Removed mandatory single parameter constrain for single parameter fits

### DIFF
--- a/docs/source/fitting_code/running.md
+++ b/docs/source/fitting_code/running.md
@@ -286,8 +286,30 @@ To do this add to the runcard
 single_parameter_fits: True
 ```
 and proceed as documented above for a normal fit.
-For both NS, MC and A the final output will be the file ``posterior.json``
-containing the independent posterior of the fitted Wilson coefficients, obtained by a series os independent single parameter fits.
+For both `NS` and `A` the final output will be the file ``fit_results.json``
+containing the independent posterior of the fitted Wilson coefficients, obtained by a series of independent single parameter fits.
+
+It is possible to perform single paramters in the presence of multiple constraints. For example
+
+```yaml
+
+single_parameter_fits: True
+uv_couplings: true
+
+coefficients:
+  # Free params
+  OWWW: {'min': -3, 'max': 3}
+  Opq1: {'min': -3, 'max': 3}
+  Opq3: {'min': -3, 'max': 3}
+
+  ## To fix ##
+  OpqMi: {'constrain': [{'Opq1': 1}, {'Opq3': -1}], 'min': -2, 'max': 2 }
+  O3pq: {'constrain': [{'Opq3': 1}], 'min': -1, 'max': 1 }
+
+```
+performs a single parameter fit for ``OWWW``, ``Opq1`` and ``Opq3``. Note that this requires `uv_couplings` to be set to
+True (this allows you to fit parameters that do not appear in the theory tables). The naming `uv_couplings` stems from fitting with
+constraints among Wilson coefficients and UV parameters.
 
 
 


### PR DESCRIPTION
This PR allows to perform single parameter fits even when in the card there are multiple constraints defined. 
E.g. this runcard now works, allowing for the fit of the Warsaw O1 and O3 in single parameter fits. (full fits are already working).

```
# Input YAML configurations for SMEFiT code

result_ID: LEP_indiv_lin

# absolute path where results are stored
result_path: results

# path to common data
data_path: /Users/luca/Applications/smefit_database/commondata

# path to theory tables, default same as data path
theory_path: /Users/luca/Applications/smefit_database/theory

# pQCD order (LO or NLO)
order: NLO

use_theory_covmat: True

use_t0: True

# SMEFT Expansion Order (NHO = Lambda^-2 , HO = Lambda^-4)
use_quad: False

# Set parameter bounds to previous SCAN result
bounds: Null

n_samples: 10000

# Datasets to include
datasets:

  - {name: LEP1_EWPOs_2006, order: LO}
  - {name: LEP_Bhabha_2013, order: LO}
  - {name: LEP_Brw_2013, order: LO}
  - {name: LEP_alphaEW, order: LO}
  - {name: LEP_eeWW_182GeV, order: LO}
  - {name: LEP_eeWW_189GeV, order: LO}
  - {name: LEP_eeWW_198GeV, order: LO}
  - {name: LEP_eeWW_206GeV, order: LO}




# Coefficients to fit
coefficients:
  # Free params
  OWWW: {'min': -3, 'max': 3}
  Opq1: {'min': -3, 'max': 3}
  Opq3: {'min': -3, 'max': 3}
  
  ## To fix ##
  OpqMi: {'constrain': [{'Opq1': 1}, {'Opq3': -1}], 'min': -2, 'max': 2 }
  O3pq: {'constrain': [{'Opq3': 1}], 'min': -1, 'max': 1 }

single_parameter_fits: true
uv_couplings: true

rot_to_fit_basis: null
```

**Note**: in order to do this we need to set `uv_couplings:true`, I think we should probably rethink the name of the variable or something like that, the function of it is basically to allow the fit of parameters that are not present in the tables.