### PR TITLE
Rename opd

### DIFF
--- a/src/smefit/coefficients.py
+++ b/src/smefit/coefficients.py
@@ -26,6 +26,11 @@ class Coefficient:
 
     def __init__(self, name, minimum, maximum, value=None, constrain=False):
         self.name = name
+        # Temporary check for deprecated operator
+        if name == "Opd":
+            raise ValueError(
+                "The operator Opd is deprecated and has been renamed. Use OpBox instead."
+            )
         self.minimum = minimum
         self.maximum = maximum
 

--- a/src/smefit/rge/wcxf.py
+++ b/src/smefit/rge/wcxf.py
@@ -19,7 +19,7 @@ cw = np.sqrt(1 - sw**2)
 wcxf_translate = {
     # Bosonic
     "OWWW": {"wc": ["W"]},
-    "Opd": {"wc": ["phiBox"]},
+    "OpBox": {"wc": ["phiBox"]},
     "OpD": {"wc": ["phiD"]},
     "OpWB": {"wc": ["phiWB"]},
     "OpG": {"wc": ["phiG"]},
@@ -104,7 +104,7 @@ wcxf_translate = {
 inverse_wcxf_translate = {
     # Bosonic
     "OWWW": {"wc": ["W"]},
-    "Opd": {"wc": ["phiBox"]},
+    "OpBox": {"wc": ["phiBox"]},
     "OpD": {"wc": ["phiD"]},
     "OpWB": {"wc": ["phiWB"]},
     "OpG": {"wc": ["phiG"]},


### PR DESCRIPTION
This PR renames Opd to OpBox in the wcxf.py and it also adds a warning (raises a ValueError) if someone tries to have it in the runcard.