### PR TITLE
adding custom row and column number to the posterior distributions

### DIFF
--- a/docs/source/report/running.md
+++ b/docs/source/report/running.md
@@ -101,7 +101,10 @@ coefficients_plots:
     dofs_show: ["Op1", "Op2"] # list of operator to be displayed (will include all the possible pairs), default is Null
 
   # show the posterior histograms
-  posterior_histograms: True
+  posterior_histograms:
+    # if both nrows and ncols are set, ncols will be inferred from nrows
+    nrows: 10 # number of rows in the histogram grid
+    ncols: 5 # number of columns in the histogram grid
 
   # show a summary table with all the given bounds
   table:

--- a/src/smefit/analyze/report.py
+++ b/src/smefit/analyze/report.py
@@ -368,6 +368,7 @@ class Report:
                 [fit.results["samples"] for fit in self.fits],
                 labels=[fit.label for fit in self.fits],
                 disjointed_lists=disjointed_lists,
+                **posterior_histograms,
             )
             figs_list.append("coefficient_histo")
 


### PR DESCRIPTION
This PR implements a new feature that lets the user set the number of rows or columns in the posterior distribution section of the report. To use this, add to the report 

```
 posterior_histograms:
    nrows: <nrows>
    ncols: -1 # optional
```

or 

```
posterior_histograms:
   nrows: -1 # optional
   ncols: <ncols>
```

In case both `nrows` and `nrows` are specified, `ncols` is inferred from `nrows` so as to fit all parameters.  One can also have them both inferred automatically to make the figure square like:

```
  posterior_histograms:
    nrows: -1  
    ncols: -1
```

 Documentation has been updated as well. 