### PR TITLE
Fix SM projections

### DIFF
--- a/docs/source/data_theory/projections.rst
+++ b/docs/source/data_theory/projections.rst
@@ -103,6 +103,7 @@ The ``projection_runcard`` specifies which datasets need to be extrapolated, by 
         coefficients:
           OtG: {constrain: True, value: 2.0}
           OpD: {constrain: True, value: -1.0}
+          OtW: {constrain: [{OtZ: 1.0}]}
 
         uv_couplings: False
         use_quad: False

--- a/src/smefit/projections/__init__.py
+++ b/src/smefit/projections/__init__.py
@@ -41,7 +41,9 @@ class Projection:
         self.theory_path = theory_path
         self.datasets = datasets
         self.projections_path = projections_path
-        self.coefficients = CoefficientManager.from_dict(coefficients)
+        self.coefficients = (
+            CoefficientManager.from_dict(coefficients) if coefficients else {}
+        )
         self.default_order = default_order
         self.use_quad = use_quad
         self.use_theory_covmat = use_theory_covmat
@@ -116,7 +118,7 @@ class Projection:
         ).absolute()
         datasets = projection_config["datasets"]
 
-        coefficients = projection_config.get("coefficients", [])
+        coefficients = projection_config.get("coefficients", {})
         default_order = projection_config.get("default_order", "LO")
         use_quad = projection_config.get("use_quad", False)
         use_theory_covmat = projection_config.get("use_theory_covmat", True)


### PR DESCRIPTION
This PR fixes a bug that was introduced in #141 , not allowing the SM projections to be produced by simply omitting the coefficients key in the runcard. 

I have also added a line in the documentation showing that constrained coefficients as dependent ones can be used.