### PR TITLE
New operators in the RGE dictionary: Heavy 2l2q and 4l

### DIFF
--- a/src/smefit/rge/wcxf.py
+++ b/src/smefit/rge/wcxf.py
@@ -83,9 +83,12 @@ wcxf_translate = {
     "OQt1": {"wc": ["qu1_3333"]},
     "OQt8": {"wc": ["qu8_3333"]},
     "Ott1": {"wc": ["uu_3333"]},
+    "Obb": {"wc": ["dd_3333"]},
     # 4 leptons
     "Oll": {"wc": ["ll_1221"]},
     "Oll1111": {"wc": ["ll_1111"]},
+    "Oll3333": {"wc": ["ll_3333"]},
+    "Olta3": {"wc": ["le_3333"]},
     # 2 quark 2 lepton operators
     "Oeu": {"wc": ["eu_1111", "eu_1122"]},
     "Oed": {"wc": ["ed_1111", "ed_1122"]},
@@ -101,6 +104,12 @@ wcxf_translate = {
     "Olb": {"wc": ["ld_1133"]},
     "Oqe": {"wc": ["qe_1111", "qe_2211"]},
     "OQe": {"wc": ["qe_3311"]},
+    "Otat": {"wc": ["eu_3333"]},
+    "OQta": {"wc": ["qe_3333"]},
+    "Otl3": {"wc": ["lu_3333"]},
+    "Otl2": {"wc": ["lu_2233"]},
+    "OQl13": {"wc": ["lq1_3333"]},
+    "OQl33": {"wc": ["lq3_3333"]},
 }
 
 # This creates a dictionary to go from Warsaw to SMEFiT.
@@ -177,9 +186,12 @@ inverse_wcxf_translate = {
     "OQt1": {"wc": ["qu1_3333"]},
     "OQt8": {"wc": ["qu8_3333"]},
     "Ott1": {"wc": ["uu_3333"]},
+    "Obb": {"wc": ["dd_3333"]},
     # 4 leptons
     "Oll": {"wc": ["ll_1221"]},
     "Oll1111": {"wc": ["ll_1111"]},
+    "Oll3333": {"wc": ["ll_3333"]},
+    "Olta3": {"wc": ["le_3333"]},
     # 2 quark 2 lepton operators
     "Oeu": {"wc": ["eu_1111"]},
     "Oed": {"wc": ["ed_1111"]},
@@ -195,4 +207,10 @@ inverse_wcxf_translate = {
     "Olb": {"wc": ["ld_1133"]},
     "Oqe": {"wc": ["qe_1111"]},
     "OQe": {"wc": ["qe_3311"]},
+    "Otat": {"wc": ["eu_3333"]},
+    "OQta": {"wc": ["qe_3333"]},
+    "Otl3": {"wc": ["lu_3333"]},
+    "Otl2": {"wc": ["lu_2233"]},
+    "OQl13": {"wc": ["lq1_3333"]},
+    "OQl33": {"wc": ["lq3_3333"]},
 }


### PR DESCRIPTION
Added several all-heavy 2-lepton-2-quark operators to the wcxf dictionary of the RGE module. This is needed to study the Z-pole blind directions found in [arXiv:2504.16558](https://inspirehep.net/literature/2915005). Additionally, added one non-all-heavy 2-lepton-2-quark  and one all-heavy 4-quark operator.

The added operators are,
`Obb` $=\mathcal{O}_{dd}^{3333}$

`Oll3333 ` $=\mathcal{O}_{ll}^{3333}$

`Olta3` = $\mathcal{O}_{le}^{3333}$

`Otat` = $\mathcal{O}_{eu}^{3333}$

`OQta` = $\mathcal{O}_{qe}^{3333}$

`Otl3` = $\mathcal{O}_{lu}^{3333}$

`Otl2` = $\mathcal{O}_{lu}^{2233}$

`OQl13` = $\mathcal{O}_{lq}^{(1),3333}$

`OQl33` = $\mathcal{O}_{lq}^{(3),3333}$