### PR TITLE
Add possibility to specify random seed in projection module

### DIFF
--- a/docs/source/data_theory/projections.rst
+++ b/docs/source/data_theory/projections.rst
@@ -74,12 +74,13 @@ and systematic uncertainties) as ``.yaml`` files in the standard SMEFiT format w
 
 .. code-block:: bash
 
-    smefit PROJ --lumi <luminosity> --noise <noise level> /path/to/projection_runcard.yaml
+    smefit PROJ --lumi <luminosity> --noise <noise level> --seed <random seed> /path/to/projection_runcard.yaml
 
 where ``<luminosity>`` specifies the luminosity of the projection in :math:`{\rm fb}^{-1}`. The noise level ``<noise level>``
 can be either ``L0`` are ``L1`` corresponding to either level 0 or level 1 projections respectively. In level 0 projections,
 the experimental central value coincides exactly with the theory prediction, while the experimental central values are fluctuated around
-the theory prediction according to the experimental uncertainties in case of level 1. If ``<noise level>`` is not specified, level 0
+the theory prediction according to the experimental uncertainties in case of level 1. The fluctuations can be controlled by the ``<random seed>`` and the data will be generated in a corresponding subfolder. If not specified, a random seed is chosen automatically.
+If ``<noise level>`` is not specified, level 0
 is assumed. If ``<luminosity>`` is not specified, the original luminosities are kept and the uncertainties are not rescaled.
 The ``projection_runcard`` specifies which datasets need to be extrapolated, by which factor to reduce the systematics, and sets the necessary paths:
 

--- a/src/smefit/cli/__init__.py
+++ b/src/smefit/cli/__init__.py
@@ -236,8 +236,15 @@ def report(report_card: pathlib.Path):
     required=False,
     help="Noise level for the projection, choose between L0 or L1. Assumes L0 by default.",
 )
-def projection(projection_card: pathlib.Path, lumi: float, noise: str):
+@click.option(
+    "--seed",
+    type=int,
+    default=None,
+    required=False,
+    help="Seed for the random number generator, if not specified, a random seed is used.",
+)
+def projection(projection_card: pathlib.Path, lumi: float, noise: str, seed: int):
     r"""Compute projection for specified dataset"""
 
     projection_setup = Projection.from_config(projection_card)
-    projection_setup.build_projection(lumi, noise)
+    projection_setup.build_projection(lumi, noise, seed)

--- a/src/smefit/projections/__init__.py
+++ b/src/smefit/projections/__init__.py
@@ -228,7 +228,7 @@ class Projection:
         fred_stat = np.sqrt(lumi_old / lumi_new)
         return stat * fred_stat
 
-    def build_projection(self, lumi_new=None, noise="L0"):
+    def build_projection(self, lumi_new=None, noise="L0", seed=None):
         """
         Constructs runcard for projection by updating the central value and statistical and
         systematic uncertainties
@@ -241,10 +241,11 @@ class Projection:
             according to the noise level
         noise: str
             Noise level for the projection, choose between L0 or L1
-        closure: bool
-            Set to true for a L1 closure test (no rescaling, only cv gets fluctuated according to
-            original uncertainties)
+        seed: int, optional
+            Seed for the random number generator, if not specified, a random seed is used
         """
+        if seed is not None:
+            np.random.seed(seed)
 
         # compute central values under projection
         cv = self.compute_cv_projection()
@@ -374,7 +375,9 @@ class Projection:
                 data_dict["data_central"] = float(cv_projection[0])
 
             projection_folder = self.projections_path
-            projection_folder.mkdir(exist_ok=True)
+            if seed is not None:
+                projection_folder = projection_folder / f"seed_{seed}"
+            projection_folder.mkdir(exist_ok=True, parents=True)
 
             if projection_folder != self.commondata_path:
                 if lumi_new is not None:


### PR DESCRIPTION
This PR adds the possibility to specify the random seed when doing data projections, only relevant for L1 data generation.