### PR TITLE
Fix pandas warning

### DIFF
--- a/src/smefit/analyze/pca.py
+++ b/src/smefit/analyze/pca.py
@@ -181,7 +181,7 @@ def impose_constrain(dataset, coefficients, update_quad=False):
     # loop on the free op and add the corrections
     for idx in range(n_free_params):
         # update all the free coefficents to 0 except from 1 and propagate
-        params = np.zeros_like(free_coeffs)
+        params = np.zeros_like(free_coeffs, dtype=float)
         params[idx] = 1.0
         temp_coeffs.set_free_parameters(params)
         temp_coeffs.set_constraints()
@@ -192,7 +192,7 @@ def impose_constrain(dataset, coefficients, update_quad=False):
         # update quadratic corrections, this will include some double counting in the mixed corrections
         if update_quad:
             for jdx in range(free_coeffs[idx:].size):
-                params = np.zeros_like(free_coeffs)
+                params = np.zeros_like(free_coeffs, dtype=float)
                 params[idx + jdx] = 1.0
                 params[idx] = 1.0
                 temp_coeffs.set_free_parameters(params)

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -435,7 +435,7 @@ class TestOptimize_MC:
             )
 
             for idx in range(free_coeffs.shape[0]):
-                params = np.zeros_like(free_coeffs)
+                params = np.zeros_like(free_coeffs, dtype=float)
                 params[idx] = 1.0
                 temp_coeff.set_free_parameters(params)
                 temp_coeff.set_constraints()


### PR DESCRIPTION
This PR addresses the pandas warning in #94 .
The problem was there only for the analytic as it calls the function "impose_contraint" which was sending an array with integer zeros instead of float ones. Fixing that removes the warning.