### PR TITLE
adding recording smefit to website

### DIFF
--- a/docs/source/fitting_code/tutorial.ipynb
+++ b/docs/source/fitting_code/tutorial.ipynb
@@ -270,7 +270,7 @@
    "cell_type": "code",
    "id": "91075427",
    "metadata": {},
-   "source": "!smefit A ./downloads/runcards/runcard_ttV.yaml",
+   "source": "!smefit A ./downloads/runcards_tutorial/runcard_ttV.yaml",
    "outputs": [],
    "execution_count": null
   },
@@ -285,7 +285,7 @@
   {
    "metadata": {},
    "cell_type": "code",
-   "source": "!smefit R ./downloads/runcards/runcard_report_ttV.yaml",
+   "source": "!smefit R ./downloads/runcards_tutorial/runcard_report_ttV.yaml",
    "id": "a33e30b444e06783",
    "outputs": [],
    "execution_count": null
@@ -350,7 +350,7 @@
   {
    "metadata": {},
    "cell_type": "code",
-   "source": "!smefit A ./downloads/runcards/runcard_tt_mtt.yaml",
+   "source": "!smefit A ./downloads/runcards_tutorial/runcard_tt_mtt.yaml",
    "id": "5c54afbc7bd42528",
    "outputs": [],
    "execution_count": null
@@ -364,19 +364,9 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c678d10b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "make_report(\"./downloads/runcards/runcard_report_tt_mtt.yaml\")"
-   ]
-  },
-  {
    "metadata": {},
    "cell_type": "code",
-   "source": "!smefit R ./downloads/runcards/runcard_report_tt_mtt.yaml",
+   "source": "!smefit R ./downloads/runcards_tutorial/runcard_report_tt_mtt.yaml",
    "id": "60cc49ef769d0c40",
    "outputs": [],
    "execution_count": null
@@ -498,7 +488,7 @@
    "cell_type": "code",
    "id": "76187f93",
    "metadata": {},
-   "source": "!smefit NS ./downloads/runcards/runcard_tt_mtt_quad.yaml",
+   "source": "!smefit NS ./downloads/runcards_tutorial/runcard_tt_mtt_quad.yaml",
    "outputs": [],
    "execution_count": null
   }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,6 +32,16 @@ When using the code please cite:
 
 - *SMEFiT: a flexible toolbox for global interpretations of particle physics data with effective field theories*, T. Giani, G. Magni and J. Rojo, :cite:`Giani:2023gfq`
 
+An introductory overview of SMEFiT was recently presented at the following workshop:
+
+.. raw:: html
+
+    <video
+      controls
+      style="width:100%; max-width:700px; height:auto; display:block;">
+      <source src="https://indico.cern.ch/event/1587395/attachments/3142763/5578327/GMT20250924-120121_Recording_1920x1200.mp4" type="video/mp4">
+    </video>
+
 Installation
 ------------
 


### PR DESCRIPTION
This PR adds https://indico.cern.ch/event/1587395/attachments/3142763/5578327/GMT20250924-120121_Recording_1920x1200.mp4 to the smefit website:

<img width="1281" height="794" alt="image" src="https://github.com/user-attachments/assets/0c01b8df-f561-41b1-b1bb-f98b404bc2a9" />


I also fixed some path issues in the tutorial - nothing major