### PR TITLE
Delete only top-level files when restarting

### DIFF
--- a/src/smefit/runner.py
+++ b/src/smefit/runner.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import itertools
 import pathlib
-import shutil
 import subprocess
 import sys
 from shutil import copyfile
@@ -68,7 +67,8 @@ class Runner:
 
         if res_folder_fit.exists():
             _logger.warning(
-                f"{res_folder_fit} already found, cleaning old results (keeping ultranest_logs and subfolders)"
+                f"{res_folder_fit} already found, "
+                f"cleaning old results (keeping ultranest_logs and subfolders)"
             )
             for item in res_folder_fit.iterdir():
                 # delete only top-level files (designed to keep ultranest_logs)


### PR DESCRIPTION
This PR changes the behaviour when running a previously run fit. Before, it was deleting the folder completely, while now it only deletes the top level files. This was breaking the possibility to resume a ultranest run when `store_raw: True` was active, since the folder was being deleted.