### PR TITLE
saving result before producing ultranest plots

### DIFF
--- a/src/smefit/optimize/ultranest.py
+++ b/src/smefit/optimize/ultranest.py
@@ -416,6 +416,8 @@ class USOptimizer(Optimizer):
             log.console.log(f"Time : {((t2 - t1) / 60.0):.3f} minutes")
             log.console.log(f"Number of samples: {result['samples'].shape[0]}")
 
+            self.save(result)
+
             if self.store_raw:
                 _logger.info("Ultranest plots being produced...")
                 sampler.plot()
@@ -430,8 +432,6 @@ class USOptimizer(Optimizer):
             for par, col in zip(self.free_parameters.index, result["samples"].T):
                 table.add_row(f"{par}", f"{col.mean():.3f}", f"{col.std():.3f}")
             log.console.print(table)
-
-            self.save(result)
 
     def save(self, result):
         """Save |NS| replicas to json inside a dictionary: {coff: [replicas values]}.


### PR DESCRIPTION
This small PR makes sure the result is saved before attempting to make plots with ultranest. My run finished, but then crashed without saving the result because it couldn't find some tex distribution, which can probably be easily fixed but new users that start from a fresh environment could run into similar issues.

```
Traceback (most recent call last):
  File "/project/theorie/jthoeve/miniconda3/envs/smefit_gpu/bin/smefit", line 7, in <module>
    sys.exit(base_command())
             ^^^^^^^^^^^^^^
  File "/project/theorie/jthoeve/miniconda3/envs/smefit_gpu/lib/python3.11/site-packages/click/core.py", line 1462, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/project/theorie/jthoeve/miniconda3/envs/smefit_gpu/lib/python3.11/site-packages/click/core.py", line 1383, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/project/theorie/jthoeve/miniconda3/envs/smefit_gpu/lib/python3.11/site-packages/click/core.py", line 1850, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/project/theorie/jthoeve/miniconda3/envs/smefit_gpu/lib/python3.11/site-packages/click/core.py", line 1246, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/project/theorie/jthoeve/miniconda3/envs/smefit_gpu/lib/python3.11/site-packages/click/core.py", line 814, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/theorie/jthoeve/smefit_release/src/smefit/cli/__init__.py", line 83, in nested_sampling
    runner.run_analysis("NS")
  File "/data/theorie/jthoeve/smefit_release/src/smefit/runner.py", line 295, in run_analysis
    self.global_analysis(optimizer)
  File "/data/theorie/jthoeve/smefit_release/src/smefit/runner.py", line 193, in global_analysis
    opt(config)
  File "/data/theorie/jthoeve/smefit_release/src/smefit/runner.py", line 165, in ultranest
    ns_opt.run_sampling()
  File "/data/theorie/jthoeve/smefit_release/src/smefit/optimize/ultranest.py", line 424, in run_sampling
    sampler.plot()
  File "/project/theorie/jthoeve/miniconda3/envs/smefit_gpu/lib/python3.11/site-packages/ultranest/integrator.py", line 3061, in plot
    self.plot_corner()
  File "/project/theorie/jthoeve/miniconda3/envs/smefit_gpu/lib/python3.11/site-packages/ultranest/integrator.py", line 3084, in plot_corner
    plt.savefig(os.path.join(self.logs['plots'], 'corner.pdf'), bbox_inches='tight')
  File "/project/theorie/jthoeve/miniconda3/envs/smefit_gpu/lib/python3.11/site-packages/matplotlib/pyplot.py", line 1251, in savefig
    res = fig.savefig(*args, **kwargs)  # type: ignore[func-returns-value]
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/project/theorie/jthoeve/miniconda3/envs/smefit_gpu/lib/python3.11/site-packages/matplotlib/figure.py", line 3490, in savefig
    self.canvas.print_figure(fname, **kwargs)
  File "/project/theorie/jthoeve/miniconda3/envs/smefit_gpu/lib/python3.11/site-packages/matplotlib/backend_bases.py", line 2157, in print_figure
    self.figure.draw(renderer)
  File "/project/theorie/jthoeve/miniconda3/envs/smefit_gpu/lib/python3.11/site-packages/matplotlib/artist.py", line 94, in draw_wrapper
    result = draw(artist, renderer, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/project/theorie/jthoeve/miniconda3/envs/smefit_gpu/lib/python3.11/site-packages/matplotlib/artist.py", line 71, in draw_wrapper
    return draw(artist, renderer)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/project/theorie/jthoeve/miniconda3/envs/smefit_gpu/lib/python3.11/site-packages/matplotlib/figure.py", line 3257, in draw
    mimage._draw_list_compositing_images(
  File "/project/theorie/jthoeve/miniconda3/envs/smefit_gpu/lib/python3.11/site-packages/matplotlib/image.py", line 134, in _draw_list_compositing_images
    a.draw(renderer)
  File "/project/theorie/jthoeve/miniconda3/envs/smefit_gpu/lib/python3.11/site-packages/matplotlib/artist.py", line 71, in draw_wrapper
    return draw(artist, renderer)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/project/theorie/jthoeve/miniconda3/envs/smefit_gpu/lib/python3.11/site-packages/matplotlib/axes/_base.py", line 3190, in draw
    self._update_title_position(renderer)
  File "/project/theorie/jthoeve/miniconda3/envs/smefit_gpu/lib/python3.11/site-packages/matplotlib/axes/_base.py", line 3144, in _update_title_position
    if title.get_window_extent(renderer).ymin < top:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/project/theorie/jthoeve/miniconda3/envs/smefit_gpu/lib/python3.11/site-packages/matplotlib/text.py", line 969, in get_window_extent
    bbox, info, descent = self._get_layout(self._renderer)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/project/theorie/jthoeve/miniconda3/envs/smefit_gpu/lib/python3.11/site-packages/matplotlib/text.py", line 373, in _get_layout
    _, lp_h, lp_d = _get_text_metrics_with_cache(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/project/theorie/jthoeve/miniconda3/envs/smefit_gpu/lib/python3.11/site-packages/matplotlib/text.py", line 69, in _get_text_metrics_with_cache
    return _get_text_metrics_with_cache_impl(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/project/theorie/jthoeve/miniconda3/envs/smefit_gpu/lib/python3.11/site-packages/matplotlib/text.py", line 77, in _get_text_metrics_with_cache_impl
    return renderer_ref().get_text_width_height_descent(text, fontprop, ismath)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/project/theorie/jthoeve/miniconda3/envs/smefit_gpu/lib/python3.11/site-packages/matplotlib/backends/_backend_pdf_ps.py", line 150, in get_text_width_height_descent
    return super().get_text_width_height_descent(s, prop, ismath)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/project/theorie/jthoeve/miniconda3/envs/smefit_gpu/lib/python3.11/site-packages/matplotlib/backend_bases.py", line 566, in get_text_width_height_descent
    return self.get_texmanager().get_text_width_height_descent(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/project/theorie/jthoeve/miniconda3/envs/smefit_gpu/lib/python3.11/site-packages/matplotlib/texmanager.py", line 367, in get_text_width_height_descent
    page, = dvi
    ^^^^^
  File "/project/theorie/jthoeve/miniconda3/envs/smefit_gpu/lib/python3.11/site-packages/matplotlib/dviread.py", line 261, in __iter__
    while self._read():
          ^^^^^^^^^^^^
  File "/project/theorie/jthoeve/miniconda3/envs/smefit_gpu/lib/python3.11/site-packages/matplotlib/dviread.py", line 343, in _read
    raise self._missing_font.to_exception()
FileNotFoundError: Matplotlib's TeX implementation searched for a file named 'phvr7t.tfm' in your texmf tree, but could not find it
```