### PR TITLE
adding figsize to pca heatmap

### DIFF
--- a/src/smefit/analyze/report.py
+++ b/src/smefit/analyze/report.py
@@ -486,7 +486,9 @@ class Report:
 
                 # TODO: check why **fit_plot got removed (see PR)
                 pca_cal.plot_heatmap(
-                    f"{self.report}/pca_heatmap_{fit.name}", title=title, figsize=plot["figsize"]
+                    f"{self.report}/pca_heatmap_{fit.name}",
+                    title=title,
+                    figsize=plot["figsize"],
                 )
                 figs_list.append(f"pca_heatmap_{fit.name}")
         self._append_section("PCA", figs=figs_list, links=links_list)


### PR DESCRIPTION
This small PR enables control over the figsize of the PCA heatmap directly from the report runcard:


```
PCA:

  fit_list: ["test_fit"]
  table: True # display a table with the list of PC decomposition
  thr_show: 1.e-2 # min value of the principal component to display

  # heatmap plot
  plot:
    figsize: [30,30] # <-------  figure size
    sv_min: 1.e-4 # min singular value to display (upper plot)
    sv_max: 1.e+5 # max singular value to display (upper plot)
    thr_show: 0.1 # min value of the principal component to display (main plot)
    title: true # if True display the fit label as title
```