### PR TITLE
Passing copy of rge dict to external likelihood

### DIFF
--- a/src/smefit/optimize/__init__.py
+++ b/src/smefit/optimize/__init__.py
@@ -80,7 +80,11 @@ class Optimizer:
 
         # load external chi2 modules as amortized objects (fast to evaluate)
         self.chi2_ext = (
-            load_external_chi2(external_chi2, self.coefficients, self.rge_dict.copy())
+            load_external_chi2(
+                external_chi2,
+                self.coefficients,
+                self.rge_dict.copy() if self.rge_dict is not None else None,
+            )
             if external_chi2
             else None
         )

--- a/src/smefit/optimize/__init__.py
+++ b/src/smefit/optimize/__init__.py
@@ -80,7 +80,7 @@ class Optimizer:
 
         # load external chi2 modules as amortized objects (fast to evaluate)
         self.chi2_ext = (
-            load_external_chi2(external_chi2, self.coefficients, self.rge_dict)
+            load_external_chi2(external_chi2, self.coefficients, self.rge_dict.copy())
             if external_chi2
             else None
         )


### PR DESCRIPTION
This PR passes a copy of the rg_dict to the external likelihood so that the original object does not get modified. This is necessary for individual fits where fits happen sequentially and one doesn't want the external likelihood to modify the rge_dict of the "internal" likelihood. 

